### PR TITLE
Refactored InstanceVariable Missing modules

### DIFF
--- a/lib/aye_commander.rb
+++ b/lib/aye_commander.rb
@@ -1,5 +1,5 @@
-require 'aye_commander/instance_variable_readable'
-require 'aye_commander/instance_variable_writeable'
+require 'aye_commander/ivar_readable'
+require 'aye_commander/ivar_writeable'
 require 'aye_commander/inspectable'
 require 'aye_commander/statusable'
 require 'aye_commander/limitable'

--- a/lib/aye_commander/command.rb
+++ b/lib/aye_commander/command.rb
@@ -21,8 +21,8 @@ module AyeCommander
 
     include Statusable
     include Inspectable
-    include InstanceVariableReadable
-    include InstanceVariableWriteable
+    include IvarReadable
+    include IvarWriteable
 
     # Initializes the command with the correct setup
     #

--- a/lib/aye_commander/ivar_readable.rb
+++ b/lib/aye_commander/ivar_readable.rb
@@ -1,6 +1,6 @@
 module AyeCommander
   # Helps a command and result repond to read methods of instance variables
-  module InstanceVariableReadable
+  module IvarReadable
     def method_missing(name, *args)
       var_name = "@#{name}"
       if instance_variable_defined? var_name

--- a/lib/aye_commander/ivar_writeable.rb
+++ b/lib/aye_commander/ivar_writeable.rb
@@ -1,11 +1,11 @@
 module AyeCommander
   # Method missing to write instance_variables
-  module InstanceVariableWriteable
+  module IvarWriteable
     def method_missing(name, *args)
-      if (match = /(.*)=\z/.match(name))
-        var_name = "@#{match[1]}"
+      if name[-1] == '='
+        var_name = "@#{name[0...-1]}"
         instance_variable_set var_name, args.first
-        self.class.uses match[1]
+        self.class.uses name[0...-1]
       else
         super
       end
@@ -16,7 +16,7 @@ module AyeCommander
     private
 
     def respond_to_missing?(name, *args)
-      /=\z/ =~ name ? true : super
+      name[-1] == '=' || super
     end
   end
 end

--- a/lib/aye_commander/resultable.rb
+++ b/lib/aye_commander/resultable.rb
@@ -19,7 +19,7 @@ module AyeCommander
       result = Class.new do
         include Inspectable
         include Statusable
-        include InstanceVariableReadable
+        include IvarReadable
 
         attr_reader(*readers)
 

--- a/spec/aye_commander/ivar_readable_spec.rb
+++ b/spec/aye_commander/ivar_readable_spec.rb
@@ -1,4 +1,4 @@
-describe AyeCommander::InstanceVariableReadable do
+describe AyeCommander::IvarReadable do
   let(:command)  { Class.new.send(:include, AyeCommander::Command) }
   let(:instance) { command.new }
   let(:result)   { command.result_class.new }

--- a/spec/aye_commander/ivar_writeable_spec.rb
+++ b/spec/aye_commander/ivar_writeable_spec.rb
@@ -1,4 +1,4 @@
-describe AyeCommander::InstanceVariableWriteable do
+describe AyeCommander::IvarWriteable do
   let(:command)  { Class.new.send(:include, AyeCommander::Command) }
   let(:instance) { command.new }
 


### PR DESCRIPTION
It felt just very awkward to have not one, but two modules names
InstanceVariableSomething, so just renamed them to IvarSomething instead
which fortunately is still easy to remember and shorter.

Also slightly improved performance on some of the methods to use simple
comparisons instead of regex. I know I really like using them but
definitely need to consider performance of the others.