### PR TITLE
Feature: Ivar extras

### DIFF
--- a/lib/aye_commander/initializable.rb
+++ b/lib/aye_commander/initializable.rb
@@ -3,8 +3,7 @@ module AyeCommander
   module Initializable
     def initialize(**args)
       args.each do |name, value|
-        ivn = name[0] == '@' ? name : "@#{name}"
-        instance_variable_set ivn, value
+        instance_variable_set to_ivar(name), value
       end
     end
   end

--- a/lib/aye_commander/inspectable.rb
+++ b/lib/aye_commander/inspectable.rb
@@ -13,7 +13,7 @@ module AyeCommander
     # Returns a hash of the specified instance_variables, default all
     def to_hash(limit = instance_variables)
       limit.each_with_object({}) do |iv, hash|
-        ivn = iv[0] == '@' ? iv : "@#{iv}".to_sym
+        ivn = to_ivar(iv)
         hash[ivn] = instance_variable_get(ivn)
         hash
       end

--- a/lib/aye_commander/ivar.rb
+++ b/lib/aye_commander/ivar.rb
@@ -8,12 +8,22 @@ module AyeCommander
       def define_missing_reader(reader)
         respond_to?(:uses) ? uses(reader) : attr_reader(reader)
       end
+
+      # Transforms the received name to instance variable form
+      def to_ivar(name)
+        name[0] == '@' ? name.to_sym : "@#{name}".to_sym
+      end
+
+      # Transforms the received name to normal variable form
+      def to_nvar(name)
+        name[0] == '@' ? name[1..-1].to_sym : name.to_sym
+      end
     end
 
     # Helps a command and result repond to read methods of instance variables
     module Readable
       def method_missing(name, *args)
-        var_name = "@#{name}"
+        var_name = to_ivar(name)
         if instance_variable_defined? var_name
           self.class.define_missing_reader(name)
           instance_variable_get var_name
@@ -24,10 +34,25 @@ module AyeCommander
         super
       end
 
+      # Removes the received instance variable name
+      def remove!(name)
+        remove_instance_variable to_ivar(name)
+      end
+
+      # Transforms the received name to instance variable form
+      def to_ivar(name)
+        self.class.to_ivar(name)
+      end
+
+      # Transforms the received name to normal variable form
+      def to_nvar(name)
+        self.class.to_nvar(name)
+      end
+
       private
 
       def respond_to_missing?(name, *args)
-        instance_variable_defined?("@#{name}") || super
+        instance_variable_defined?(to_ivar(name)) || super
       rescue NameError
         super
       end
@@ -37,7 +62,7 @@ module AyeCommander
     module Writeable
       def method_missing(name, *args)
         if name[-1] == '='
-          var_name = "@#{name[0...-1]}"
+          var_name = to_ivar(name[0...-1])
           instance_variable_set var_name, args.first
           self.class.uses name[0...-1]
         else

--- a/spec/aye_commander/ivar_spec.rb
+++ b/spec/aye_commander/ivar_spec.rb
@@ -15,6 +15,36 @@ describe AyeCommander::Ivar::ClassMethods do
       expect(result).to_not respond_to :taco=
     end
   end
+
+  context '.to_ivar' do
+    it 'returns itself when the name is already in ivar form' do
+      expect(command.to_ivar :@var).to eq :@var
+    end
+
+    it 'returns the ivar form when name is not in ivar form' do
+      expect(command.to_ivar :var).to eq :@var
+    end
+
+    it 'is able to handle strings' do
+      expect(command.to_ivar '@var').to eq :@var
+      expect(command.to_ivar 'var').to  eq :@var
+    end
+  end
+
+  context '.to_nvar' do
+    it 'returns itself when name is already in nvar form' do
+      expect(command.to_nvar :var).to eq :var
+    end
+
+    it 'returns the nvar form when name is not in nvar form' do
+      expect(command.to_nvar :@var).to eq :var
+    end
+
+    it 'is able to handle strings' do
+      expect(command.to_nvar '@var').to eq :var
+      expect(command.to_nvar 'var').to  eq :var
+    end
+  end
 end
 
 describe AyeCommander::Ivar::Readable do
@@ -35,6 +65,27 @@ describe AyeCommander::Ivar::Readable do
       expect(command).to receive(:define_missing_reader).with(:taco)
       instance.instance_variable_set :@taco, :badger
       instance.taco
+    end
+
+    context '#remove!' do
+      it 'removes an instance variable' do
+        instance.remove!(:status)
+        expect(instance.instance_variables).to be_empty
+      end
+    end
+
+    context '#to_ivar' do
+      it 'calls the .to_ivar' do
+        expect(command).to receive(:to_ivar).with(:var)
+        instance.to_ivar(:var)
+      end
+    end
+
+    context '#to_nvar' do
+      it 'calls the .to_nvar' do
+        expect(command).to receive(:to_nvar).with(:var)
+        instance.to_nvar(:var)
+      end
     end
   end
 

--- a/spec/aye_commander/ivar_spec.rb
+++ b/spec/aye_commander/ivar_spec.rb
@@ -66,26 +66,27 @@ describe AyeCommander::Ivar::Readable do
       instance.instance_variable_set :@taco, :badger
       instance.taco
     end
+  end
 
-    context '#remove!' do
-      it 'removes an instance variable' do
-        instance.remove!(:status)
-        expect(instance.instance_variables).to be_empty
-      end
+  context '#remove!' do
+    it 'removes an instance variable' do
+      instance.remove!(:status)
+      expect(instance.instance_variables).to be_empty
     end
+  end
 
-    context '#to_ivar' do
-      it 'calls the .to_ivar' do
-        expect(command).to receive(:to_ivar).with(:var)
-        instance.to_ivar(:var)
-      end
+  context '#to_ivar' do
+    it 'calls the .to_ivar' do
+      instance
+      expect(command).to receive(:to_ivar).with(:var)
+      instance.to_ivar(:var)
     end
+  end
 
-    context '#to_nvar' do
-      it 'calls the .to_nvar' do
-        expect(command).to receive(:to_nvar).with(:var)
-        instance.to_nvar(:var)
-      end
+  context '#to_nvar' do
+    it 'calls the .to_nvar' do
+      expect(command).to receive(:to_nvar).with(:var)
+      instance.to_nvar(:var)
     end
   end
 


### PR DESCRIPTION
Added several methods to Ivar
- .to_ivar To transform a name into ivar form
- .to_nvar To transform a name into nvar form
- #to_ivar Same as above, instance level
- #to_nvar Same as above, instance level
- #remove! Removes an instance variable from the object

Probably this was bothering me the most.
This looks cleaner I just hope someone doesn't randomly names a method
the same way. blargh.