### PR TITLE
Feature: Abort hooks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -299,7 +299,8 @@ ProcessCommand.call
 == Getting Hooked
 
 A command also comes with your standard set of before, around and after hooks to tweak the command.
-The easiest way to understand them, it to see the order of execution of your command.
+Additionaly commands come bundled with a fourth kind of hook, the aborted hook.  The easiest way to
+understand them, it to see the order of execution of a command.
 
 [source,ruby]
 ----
@@ -310,6 +311,7 @@ def call
   before_hooks
   around_hooks { call_command }
   after_hooks
+  aborted_hooks if aborted
   return_result
 end
 ----
@@ -323,9 +325,6 @@ Before going deeper into each kind of hook it's worth mentioning the behavior wh
   `prepend: true` option.
 - It might be obvious but worth noting that hooks are run in the command instance; as such you have
   access to everything the command has.
-
-NOTE: Remember that calling `abort!` will stop the command on it's tracks and return the result
-immediately. This means that if you call `abort!` during `call`, after_hooks *WILL NOT* run.
 
 [source,ruby]
 ----
@@ -378,6 +377,13 @@ things:
 
 After hooks are the easiest to understand. They run after your command was called, but before the
 result is created, so if you need to tweak your results a bit you can do it in here!
+
+=== Aborted Hooks
+
+As you might imagine, these hooks are only run if you abort the command. Why do we need them in the
+first place? Well as you may remember, calling `abort!` will stop the command on its tracks and
+return the result immediately. This means that if you call `abort!` during `call`, after_hooks
+*WILL NOT* run. For these cases, you might want to use an abort hook instead.
 
 === Around Hooks
 

--- a/lib/aye_commander/abortable.rb
+++ b/lib/aye_commander/abortable.rb
@@ -11,7 +11,7 @@ module AyeCommander
 
     # Throws an :abort! to stop the current command flow
     def abort!
-      throw :abort!
+      throw :abort!, true
     end
   end
 end

--- a/lib/aye_commander/command.rb
+++ b/lib/aye_commander/command.rb
@@ -17,11 +17,12 @@ module AyeCommander
       def call(skip_cleanup: false, **args)
         command = new(args)
         validate_arguments(args)
-        abortable do
+        aborted = abortable do
           call_before_hooks(command)
           around_hooks.any? ? call_around_hooks(command) : command.call
           call_after_hooks(command)
         end
+        abortable { call_aborted_hooks(command) } if aborted
         result(command, skip_cleanup)
       end
     end

--- a/lib/aye_commander/hookable.rb
+++ b/lib/aye_commander/hookable.rb
@@ -2,7 +2,7 @@ module AyeCommander
   module Hookable
     # Hooks allow to run something, before, around and after the command runs.
     module ClassMethods
-      TYPES = %i(before around after).freeze
+      TYPES = %i(before around after aborted).freeze
 
       TYPES.each do |kind|
         # Defines .before .around and .after

--- a/lib/aye_commander/hookable.rb
+++ b/lib/aye_commander/hookable.rb
@@ -5,7 +5,7 @@ module AyeCommander
       TYPES = %i(before around after aborted).freeze
 
       TYPES.each do |kind|
-        # Defines .before .around and .after
+        # Defines .before .around .after and .aborted
         # Each simply save the hooks in an array.
         define_method kind do |*args, prepend: false, &block|
           args.push block if block
@@ -16,13 +16,14 @@ module AyeCommander
           end
         end
 
-        # Defines .before_hooks .around_hooks and .after_hooks
+        # Defines .before_hooks .around_hooks .after_hooks and .aborted_hooks
         # Public interface in case the user wants to see their defined hooks
         define_method "#{kind}_hooks" do
           hooks[kind]
         end
 
-        # Defines .call_before_hooks .call_around_hooks and .call_after_hooks
+        # Defines .call_before_hooks .call_around_hooks .call_after_hooks and
+        # .call_aborted_hooks
         # Calls the hooks one by one
         define_method "call_#{kind}_hooks" do |command|
           prepare_hooks(kind, command).each(&:call)

--- a/spec/aye_commander/abortable_spec.rb
+++ b/spec/aye_commander/abortable_spec.rb
@@ -18,7 +18,7 @@ describe AyeCommander::Abortable do
 
   context '#abort' do
     it 'throws with :abort! symbol' do
-      expect(instance).to receive(:throw).with(:abort!)
+      expect(instance).to receive(:throw).with(:abort!, true)
       instance.abort!
     end
   end

--- a/spec/aye_commander/command_spec.rb
+++ b/spec/aye_commander/command_spec.rb
@@ -13,11 +13,18 @@ describe AyeCommander::Command::ClassMethods do
       command.call(args)
     end
 
+    it 'runs the aborted hooks if command was aborted' do
+      allow(command).to  receive(:call_before_hooks){ throw :abort!, true }
+      expect(command).to receive(:call_aborted_hooks)
+      command.call(args)
+    end
+
     it 'calls several methods in the abortable block' do
       allow(command).to   receive(:new).and_return(instance)
       expect(command).to  receive(:call_before_hooks)
       expect(instance).to receive(:call)
       expect(command).to  receive(:call_after_hooks)
+      expect(command).to_not receive(:call_aborted_hooks)
       command.call(args)
     end
 


### PR DESCRIPTION
Abort hooks run only when the command aborted.
Useful to tweak your command in case of an `abort!`