### PR TITLE
Feature: Shareable

### DIFF
--- a/lib/aye_commander.rb
+++ b/lib/aye_commander.rb
@@ -4,6 +4,7 @@ require 'aye_commander/initializable'
 require 'aye_commander/inspectable'
 require 'aye_commander/ivar'
 require 'aye_commander/limitable'
+require 'aye_commander/shareable'
 require 'aye_commander/status'
 require 'aye_commander/errors'
 

--- a/lib/aye_commander/command.rb
+++ b/lib/aye_commander/command.rb
@@ -16,6 +16,7 @@ module AyeCommander
       include Ivar::ClassMethods
       include Limitable::ClassMethods
       include Resultable::ClassMethods
+      include Shareable::ClassMethods
       include Status::ClassMethods
 
       # This method is what the user calls to run their command
@@ -29,12 +30,6 @@ module AyeCommander
         end
         abortable { call_aborted_hooks(command) } if aborted
         result(command, skip_cleanup)
-      end
-
-      # This ensures that class methods are extended when Command is included
-      def included(includer)
-        super
-        includer.extend ClassMethods
       end
     end
 

--- a/lib/aye_commander/command.rb
+++ b/lib/aye_commander/command.rb
@@ -1,9 +1,13 @@
 module AyeCommander
   # This is the meat of AyeComander, what you will include in your commands.
   module Command
-    def self.included(includer)
-      includer.extend ClassMethods
-    end
+    include Abortable
+    include Initializable
+    include Inspectable
+    include Ivar::Readable
+    include Ivar::Writeable
+    include Status::Readable
+    include Status::Writeable
 
     # Class Methods to be extended to the includer
     module ClassMethods
@@ -14,6 +18,7 @@ module AyeCommander
       include Resultable::ClassMethods
       include Status::ClassMethods
 
+      # This method is what the user calls to run their command
       def call(skip_cleanup: false, **args)
         command = new(args)
         validate_arguments(args)
@@ -25,15 +30,15 @@ module AyeCommander
         abortable { call_aborted_hooks(command) } if aborted
         result(command, skip_cleanup)
       end
+
+      # This ensures that class methods are extended when Command is included
+      def included(includer)
+        super
+        includer.extend ClassMethods
+      end
     end
 
-    include Abortable
-    include Initializable
-    include Inspectable
-    include Ivar::Readable
-    include Ivar::Writeable
-    include Status::Readable
-    include Status::Writeable
+    extend ClassMethods
 
     # Initializes the command with the correct setup
     #

--- a/lib/aye_commander/shareable.rb
+++ b/lib/aye_commander/shareable.rb
@@ -1,0 +1,32 @@
+module AyeCommander
+  module Shareable
+    # This module serves to make sure that when included or inherited everything
+    # related to the command is preserved
+    # Prepend is not really supported, but you really shouldnt be prepending a
+    # Command so... meh
+    module ClassMethods
+      # This ensures that class methods are extended when Command is included
+      def included(includer)
+        super
+        includer.extend AyeCommander::Command::ClassMethods
+        %i(@limiters @succeeds @hooks).each do |var|
+          if instance_variable_defined? var
+            includer.instance_variable_set var, instance_variable_get(var)
+          end
+        end
+      end
+
+      # Rubys object model already links the ancestry path of singleton classes
+      # when using classic inheritance so no need to extend. Just need to add
+      # the variables to the inheriter.
+      def inherited(inheriter)
+        super
+        %i(@limiters @succeeds @hooks).each do |var|
+          if instance_variable_defined? var
+            inheriter.instance_variable_set var, instance_variable_get(var)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aye_commander/command_spec.rb
+++ b/spec/aye_commander/command_spec.rb
@@ -41,16 +41,6 @@ describe AyeCommander::Command do
   let(:command)  { Class.new.send(:include, AyeCommander::Command) }
   let(:instance) { command.new }
 
-  context 'when included' do
-    it 'should add the class methods to the includer' do
-      expect(command.singleton_class).to include AyeCommander::Command::ClassMethods
-    end
-
-    it 'should add the instance methods to the includer' do
-      expect(command).to include AyeCommander::Command
-    end
-  end
-
   context '#initialize' do
     it 'sets the status to :success if no other succeed has been set' do
       command.succeeds_with :potato

--- a/spec/aye_commander/shareable_spec.rb
+++ b/spec/aye_commander/shareable_spec.rb
@@ -1,0 +1,41 @@
+describe AyeCommander::Shareable::ClassMethods do
+  let(:command)   { Class.new.send(:include,  AyeCommander::Command) }
+  let(:inheriter) { Class.new(command) }
+  let(:includer)  { Module.new.send(:include, AyeCommander::Command) }
+  let(:includer2) { Module.new.send(:include, includer) }
+
+  context '.included' do
+    it 'ensures that the includer has command methods available' do
+      expect(includer.ancestors).to include AyeCommander::Command
+      expect(includer.singleton_class.ancestors).to include AyeCommander::Command::ClassMethods
+    end
+
+    it 'ensure that even down the line the command methods are available' do
+      expect(includer2.ancestors).to include AyeCommander::Command
+      expect(includer2.singleton_class.ancestors).to include AyeCommander::Command::ClassMethods
+    end
+
+    it 'adds the needed instance variables to the further includers' do
+      includer.receives :hopefully_this
+      includer.succeeds_with :inclusion
+      expect(includer2.receives).to include :hopefully_this
+      expect(includer2.succeeds).to include :inclusion
+      expect(includer2.send :hooks).to be_empty
+    end
+  end
+
+  context '.inherited' do
+    it 'has access to the command class methods' do
+      expect(inheriter.ancestors).to include AyeCommander::Command
+      expect(inheriter.singleton_class.ancestors).to include AyeCommander::Command::ClassMethods
+    end
+
+    it 'adds the needed instance variables to the further inheriters' do
+      command.receives :hopefully_this
+      command.succeeds_with :inclusion
+      expect(inheriter.receives).to include :hopefully_this
+      expect(inheriter.succeeds).to include :inclusion
+      expect(inheriter.send :hooks).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
This allows commands to be shareable down the line.
In theory this will allow you to add functionality (hooks, limits,
status) to modules or with classic inheritance.

Yes, class instance variables are being copied over to new classes. This
would actually not be an ok approach if it were not because in theory
Command classes are a one method object. Polluting the classes too much
is not too pretty.

The other downside that comes with this approach is that the
hooks/limits/suceeds status that are added will only be added in load
time. Once you've inherited if you dynamically add something to the
parent class or module it will be 'stuck' there. If such is your case,
you probably should use ActiveSupport::Concern's approach instead.