### PR TITLE
Experimental: Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
 language: ruby
 rvm:
-  - 2.0
+  - 2.0.0
+  - 2.2.5
+  - 2.3.1
+  - ruby-head
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
Previously while in development travis run version 2.0.0 and I developed
in 2.3.1.
This made the builds run faster so I didn't have to worry too much about
too many version.

In this commit all stable releases are added to the travis job to ensure
nothing breaks over the versions.