### PR TITLE
Cleanup: Specs

### DIFF
--- a/spec/aye_commander/abortable_spec.rb
+++ b/spec/aye_commander/abortable_spec.rb
@@ -1,5 +1,5 @@
 describe AyeCommander::Abortable::ClassMethods do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
+  include_context :command
 
   context '.abortable' do
     it 'does nothing if nothing happens' do
@@ -13,8 +13,7 @@ describe AyeCommander::Abortable::ClassMethods do
 end
 
 describe AyeCommander::Abortable do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   context '#abort' do
     it 'throws with :abort! symbol' do

--- a/spec/aye_commander/callable_spec.rb
+++ b/spec/aye_commander/callable_spec.rb
@@ -1,6 +1,5 @@
 describe AyeCommander::Callable::ClassMethods do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   context '.call' do
     let(:args) { { some: :other, irrelevant: :args } }
@@ -14,7 +13,7 @@ describe AyeCommander::Callable::ClassMethods do
     end
 
     it 'runs the aborted hooks if command was aborted' do
-      allow(command).to  receive(:call_before_hooks){ throw :abort!, :aborted }
+      allow(command).to  receive(:call_before_hooks) { throw :abort!, :aborted }
       expect(command).to receive(:call_aborted_hooks)
       command.call(args)
     end
@@ -38,8 +37,7 @@ describe AyeCommander::Callable::ClassMethods do
 end
 
 describe AyeCommander::Callable do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   context '#call' do
     it 'exists' do

--- a/spec/aye_commander/command_spec.rb
+++ b/spec/aye_commander/command_spec.rb
@@ -1,6 +1,5 @@
 describe AyeCommander::Command do
-  let(:command)   { Class.new.send(:include, AyeCommander::Command) }
-  let(:commandsc) { command.singleton_class }
+  include_context :command
 
   context 'a command' do
     it 'includes the necessary instance modules' do

--- a/spec/aye_commander/commander_spec.rb
+++ b/spec/aye_commander/commander_spec.rb
@@ -1,12 +1,5 @@
 describe AyeCommander::Commander::ClassMethods do
-  let(:includer)  { Module.new.send(:include, AyeCommander::Commander) }
-  let(:includer2) { Module.new.send(:include, includer) }
-  let(:inheriter) { Class.new(commander) }
-
-  let(:commander) { Class.new.send(:include,  AyeCommander::Commander) }
-  let(:instance)  { commander.new }
-
-  let(:command)   { Class.new.send(:include, AyeCommander::Command) }
+  include_context :commander
 
   context '.included' do
     it 'includes Commanders Class Methods when included' do
@@ -87,12 +80,12 @@ describe AyeCommander::Commander::ClassMethods do
   context '.abort_on_failure' do
     it 'sets the @abort_on_failure to true when called without arguments' do
       commander.abort_on_failure
-      expect(commander.instance_variable_get :@abort_on_failure).to be true
+      expect(commander.instance_variable_get(:@abort_on_failure)).to be true
     end
 
     it 'sets the @abort_on_failure to the received argument' do
       commander.abort_on_failure false
-      expect(commander.instance_variable_get :@abort_on_failure).to be false
+      expect(commander.instance_variable_get(:@abort_on_failure)).to be false
     end
   end
 
@@ -106,10 +99,7 @@ describe AyeCommander::Commander::ClassMethods do
 end
 
 describe AyeCommander::Commander do
-  let(:commander) { Class.new.send(:include, AyeCommander::Commander) }
-  let(:instance)  { commander.new }
-  let(:command)   { Class.new.send(:include, AyeCommander::Command) }
-  let(:commandi)  { command.new }
+  include_context :commander
 
   context '#initialize' do
     it 'initializes the commander with the required variables' do

--- a/spec/aye_commander/errors_spec.rb
+++ b/spec/aye_commander/errors_spec.rb
@@ -7,7 +7,7 @@ describe AyeCommander::MissingRequiredArgumentError do
 
   it 'should have a descriptive message of the error' do
     errori = error.new [:taco]
-    expect(errori.message).to eq "Missing required arguments: [:taco]"
+    expect(errori.message).to eq 'Missing required arguments: [:taco]'
   end
 end
 
@@ -20,6 +20,6 @@ describe AyeCommander::UnexpectedReceivedArgumentError do
 
   it 'should have a descriptive message of the error' do
     errori = error.new [:taco]
-    expect(errori.message).to eq "Received unexpected arguments: [:taco]"
+    expect(errori.message).to eq 'Received unexpected arguments: [:taco]'
   end
 end

--- a/spec/aye_commander/hookable_spec.rb
+++ b/spec/aye_commander/hookable_spec.rb
@@ -1,13 +1,12 @@
 describe AyeCommander::Hookable::ClassMethods do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   %i(before around after aborted).each do |kind|
     context ".#{kind}" do
       it "adds the args to the #{kind} hooks array" do
         command.send kind, :some, :method
         expect(command.send("#{kind}_hooks")).to eq [:some, :method]
-        expect(command.instance_variable_get :@hooks).to_not be_empty
+        expect(command.instance_variable_get(:@hooks)).to_not be_empty
         expect(command.instance_variable_get(:@hooks).default).to be_empty
       end
 
@@ -20,24 +19,24 @@ describe AyeCommander::Hookable::ClassMethods do
       it 'adds the args at the end of the array' do
         command.send kind, :first
         command.send kind, :second, :third
-        expect(command.send "#{kind}_hooks").to eq [:first, :second, :third]
+        expect(command.send("#{kind}_hooks")).to eq [:first, :second, :third]
       end
 
       it 'adds the args at the beginning of the array with the prepend option' do
         command.send kind, :first
         command.send kind, :second, :third, prepend: true
-        expect(command.send "#{kind}_hooks").to eq [:second, :third, :first]
+        expect(command.send("#{kind}_hooks")).to eq [:second, :third, :first]
       end
     end
 
     context ".#{kind}_hooks" do
       it 'returns empty array with nothing set' do
-        expect(command.send "#{kind}_hooks").to eq []
+        expect(command.send("#{kind}_hooks")).to eq []
       end
 
       it 'returns the array of hooks' do
         command.instance_variable_set :@hooks, kind => [:hello]
-        expect(command.send "#{kind}_hooks").to eq [:hello]
+        expect(command.send("#{kind}_hooks")).to eq [:hello]
       end
     end
   end
@@ -52,13 +51,13 @@ describe AyeCommander::Hookable::ClassMethods do
       end
 
       it 'makes all supported hooks callable' do
-        expect(command.send "call_#{kind}_hooks", instance).to all(respond_to :call)
+        expect(command.send("call_#{kind}_hooks", instance)).to all(respond_to :call)
       end
 
       it 'calls all the prepared hooks' do
         hooks = command.send "call_#{kind}_hooks", instance
         allow(command).to receive(:prepare_hooks).and_return(hooks)
-        expect(hooks).to all(receive :call)
+        expect(hooks).to all(receive(:call))
         command.send "call_#{kind}_hooks", instance
       end
 
@@ -72,7 +71,7 @@ describe AyeCommander::Hookable::ClassMethods do
   context '.call_around_hooks' do
     before :each do
       body = lambda do |step|
-        @order ||=[]
+        @order ||= []
         number = order.count + 1
         @order << number
 
@@ -100,7 +99,7 @@ describe AyeCommander::Hookable::ClassMethods do
 
     it 'should call the hooks in the correct order' do
       command.call_around_hooks(instance)
-      expect(instance.order).to eq [1,2,3,4,4,3,2,1]
+      expect(instance.order).to eq [1, 2, 3, 4, 4, 3, 2, 1]
     end
   end
 end

--- a/spec/aye_commander/initializable_spec.rb
+++ b/spec/aye_commander/initializable_spec.rb
@@ -1,6 +1,5 @@
 describe AyeCommander::Initializable do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   context '#initialize' do
     it 'sets the instance variables with the received arguments' do
@@ -16,7 +15,7 @@ describe AyeCommander::Initializable do
     end
 
     it 'is able to handle the case when no args are received' do
-      expect{ command.new }.to_not raise_error
+      expect { command.new }.to_not raise_error
     end
 
     context 'when a command' do

--- a/spec/aye_commander/inspectable_spec.rb
+++ b/spec/aye_commander/inspectable_spec.rb
@@ -1,6 +1,5 @@
 describe AyeCommander::Inspectable do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   before :each do
     instance.instance_variable_set :@variable, :something
@@ -9,7 +8,7 @@ describe AyeCommander::Inspectable do
 
   context '#inspect' do
     it 'gives a string representation of the innards of the class' do
-      expect(instance.inspect).to match /#<#<Class:\dx\w+> @status: success, @variable: something, @other: potato>/
+      expect(instance.inspect).to match(/#<#<Class:\dx\w+> @status: success, @variable: something, @other: potato>/)
     end
   end
 

--- a/spec/aye_commander/ivar_spec.rb
+++ b/spec/aye_commander/ivar_spec.rb
@@ -1,7 +1,5 @@
 describe AyeCommander::Ivar::ClassMethods do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
-  let(:result)   { command.result_class.new }
+  include_context :command
 
   context '.define_missing_reader' do
     it 'calls uses if its a command' do
@@ -18,42 +16,41 @@ describe AyeCommander::Ivar::ClassMethods do
 
   context '.to_ivar' do
     it 'returns itself when the name is already in ivar form' do
-      expect(command.to_ivar :@var).to eq :@var
+      expect(command.to_ivar(:@var)).to eq :@var
     end
 
     it 'returns the ivar form when name is not in ivar form' do
-      expect(command.to_ivar :var).to eq :@var
+      expect(command.to_ivar(:var)).to eq :@var
     end
 
     it 'is able to handle strings' do
-      expect(command.to_ivar '@var').to eq :@var
-      expect(command.to_ivar 'var').to  eq :@var
+      expect(command.to_ivar('@var')).to eq :@var
+      expect(command.to_ivar('var')).to  eq :@var
     end
   end
 
   context '.to_nvar' do
     it 'returns itself when name is already in nvar form' do
-      expect(command.to_nvar :var).to eq :var
+      expect(command.to_nvar(:var)).to eq :var
     end
 
     it 'returns the nvar form when name is not in nvar form' do
-      expect(command.to_nvar :@var).to eq :var
+      expect(command.to_nvar(:@var)).to eq :var
     end
 
     it 'is able to handle strings' do
-      expect(command.to_nvar '@var').to eq :var
-      expect(command.to_nvar 'var').to  eq :var
+      expect(command.to_nvar('@var')).to eq :var
+      expect(command.to_nvar('var')).to  eq :var
     end
   end
 end
 
 describe AyeCommander::Ivar::Readable do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   context '#method_missing' do
     it 'raises if asked a method without an instance variable defined' do
-      expect { instance.taco  }.to raise_error NoMethodError
+      expect { instance.taco }.to raise_error NoMethodError
     end
 
     it 'responds if asked the name of an instance variable' do
@@ -107,8 +104,7 @@ describe AyeCommander::Ivar::Readable do
 end
 
 describe AyeCommander::Ivar::Writeable do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   context '#method_missing' do
     it 'responds to equality assignments' do

--- a/spec/aye_commander/limitable_spec.rb
+++ b/spec/aye_commander/limitable_spec.rb
@@ -1,6 +1,5 @@
-describe AyeCommander::Limitable do
-  let(:command)   { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance)  { command.new }
+describe AyeCommander::Limitable::ClassMethods do
+  include_context :command
   let(:args)      { %i(arg1 arg2) }
 
   context '.uses' do
@@ -102,7 +101,7 @@ describe AyeCommander::Limitable do
 
     it 'does nothing if it receives extra arguments' do
       command.requires :hello, :you
-      expect { command.validate_required_arguments **args, extra: :arg }.to_not raise_error
+      expect { command.validate_required_arguments(**args, extra: :arg) }.to_not raise_error
     end
 
     it 'raises an error when the required arguments are not fully contained in the received ones' do

--- a/spec/aye_commander/resultable_spec.rb
+++ b/spec/aye_commander/resultable_spec.rb
@@ -1,23 +1,21 @@
 describe AyeCommander::Resultable::ClassMethods do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
-  let(:result_class) { command.result_class }
+  include_context :command
 
   context '.result' do
     it 'returns the command if command option is specified' do
-      expect(command.result instance, :command).to eq instance
+      expect(command.result(instance, :command)).to eq instance
     end
 
     it 'calls and returns .new_result with the complete hash if true option is specified' do
       expect(instance).to receive(:to_hash).and_return(:stubbed)
       expect(command).to  receive(:new_result).with(:stubbed).and_return(:result)
-      expect(command.result instance, true).to eq :result
+      expect(command.result(instance, true)).to eq :result
     end
 
     it 'calls and returns .new_result with the result hash if no option is specified' do
       expect(instance).to receive(:to_result_hash).and_return(:stubbed)
       expect(command).to  receive(:new_result).with(:stubbed).and_return(:result)
-      expect(command.result instance, false).to eq :result
+      expect(command.result(instance, false)).to eq :result
     end
   end
 
@@ -45,9 +43,7 @@ describe AyeCommander::Resultable::ClassMethods do
     it 'only defines the class once' do
       expect(result_class.object_id).to eq command.result_class.object_id
     end
-  end
 
-  context 'p.define_result_class' do
     it 'includes the necessary result modules' do
       expect(result_class).to include AyeCommander::Initializable
       expect(result_class).to include AyeCommander::Inspectable

--- a/spec/aye_commander/shareable_spec.rb
+++ b/spec/aye_commander/shareable_spec.rb
@@ -1,8 +1,5 @@
 describe AyeCommander::Shareable::ClassMethods do
-  let(:command)   { Class.new.send(:include,  AyeCommander::Command) }
-  let(:inheriter) { Class.new(command) }
-  let(:includer)  { Module.new.send(:include, AyeCommander::Command) }
-  let(:includer2) { Module.new.send(:include, includer) }
+  include_context :command
 
   context '.included' do
     it 'ensures that the includer has command methods available' do
@@ -20,7 +17,7 @@ describe AyeCommander::Shareable::ClassMethods do
       includer.succeeds_with :inclusion
       expect(includer2.receives).to include :hopefully_this
       expect(includer2.succeeds).to include :inclusion
-      expect(includer2.send :hooks).to be_empty
+      expect(includer2.send(:hooks)).to be_empty
     end
   end
 
@@ -35,7 +32,7 @@ describe AyeCommander::Shareable::ClassMethods do
       command.succeeds_with :inclusion
       expect(inheriter.receives).to include :hopefully_this
       expect(inheriter.succeeds).to include :inclusion
-      expect(inheriter.send :hooks).to be_empty
+      expect(inheriter.send(:hooks)).to be_empty
     end
   end
 end

--- a/spec/aye_commander/status_spec.rb
+++ b/spec/aye_commander/status_spec.rb
@@ -1,6 +1,5 @@
 describe AyeCommander::Status::ClassMethods do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   context '.succeeds' do
     it 'returns [:success] if nothing else has been set' do
@@ -42,8 +41,7 @@ describe AyeCommander::Status::ClassMethods do
 end
 
 describe AyeCommander::Status::Readable do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   context 'when included' do
     it 'adds #status method' do
@@ -77,8 +75,7 @@ describe AyeCommander::Status::Readable do
 end
 
 describe AyeCommander::Status::Writeable do
-  let(:command)  { Class.new.send(:include, AyeCommander::Command) }
-  let(:instance) { command.new }
+  include_context :command
 
   context 'when included' do
     it 'adds #status= method' do
@@ -98,4 +95,3 @@ describe AyeCommander::Status::Writeable do
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,40 @@ end
 
 require 'pry'
 require 'aye_commander'
+
+# Shared context for command tests
+shared_context :command do
+  let(:command) do
+    Class.new do
+      include AyeCommander::Command
+      define_method(:call) {}
+    end
+  end
+
+  let(:commandsc)    { command.singleton_class }
+  let(:instance)     { command.new }
+  let(:result)       { command.result_class.new }
+  let(:result_class) { command.result_class }
+
+  let(:inheriter) { Class.new(command) }
+  let(:includer)  { Module.new.send(:include, AyeCommander::Command) }
+  let(:includer2) { Module.new.send(:include, includer) }
+end
+
+# Shared context for commander tests
+shared_context :commander do
+  let(:command) do
+    Class.new do
+      include AyeCommander::Command
+      define_method(:call) {}
+    end
+  end
+
+  let(:commander) { Class.new.send(:include, AyeCommander::Commander) }
+  let(:instance)  { commander.new }
+  let(:commandi)  { command.new }
+
+  let(:includer)  { Module.new.send(:include, AyeCommander::Commander) }
+  let(:includer2) { Module.new.send(:include, includer) }
+  let(:inheriter) { Class.new(commander) }
+end


### PR DESCRIPTION
Cleaned up specs using rubocop and shared contexts.
I've been meaning to do this for a while now.

Specs now use shared context to not repeat the same lets over and over.
Also used rubocop to ensure that syntax over there is not too ugly. The only "offenses" left are line length, which in my opinion are pretty acceptable on specs.