### PR TITLE
Bug: Fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rake'
 group :test do
   gem 'pry'
   gem 'rspec'
+  gem 'rubocop'
   gem 'simplecov'
   gem 'codeclimate-test-reporter', require: nil
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ gemspec
 gem 'rake'
 
 group :test do
+  gem 'codeclimate-test-reporter', require: nil
   gem 'pry'
   gem 'rspec'
   gem 'rubocop'
   gem 'simplecov'
-  gem 'codeclimate-test-reporter', require: nil
 end

--- a/lib/aye_commander/callable.rb
+++ b/lib/aye_commander/callable.rb
@@ -35,7 +35,6 @@ module AyeCommander
     # #call is what a user redefines in their own command, and what he
     # customizes to give a command the behavior he desires.
     # An empty call is defined in a command so they can be run even without one.
-    def call
-    end
+    define_method(:call) {}
   end
 end

--- a/lib/aye_commander/hookable.rb
+++ b/lib/aye_commander/hookable.rb
@@ -6,7 +6,7 @@ module AyeCommander
     # All hook functionality is defined at a class level, but runs at instance
     # level
     module ClassMethods
-      TYPES = %i(before around after aborted).freeze
+      TYPES = %i[before around after aborted].freeze
 
       TYPES.each do |kind|
         # Defines .before .around .after and .aborted

--- a/lib/aye_commander/limitable.rb
+++ b/lib/aye_commander/limitable.rb
@@ -5,7 +5,7 @@ module AyeCommander
     # Limitable is a module which functionality is completely defined at class
     # level.
     module ClassMethods
-      LIMITERS = %i(receives requires returns).freeze
+      LIMITERS = %i[receives requires returns].freeze
 
       # Contains all the limiters
       def limiters
@@ -54,13 +54,24 @@ module AyeCommander
 
       # Validates the limiter arguments
       def validate_arguments(args, skip_validations: false)
-        unless [true, :requires].include?(skip_validations) || requires.empty?
+        if validate_required_arguments?(skip_validations)
           validate_required_arguments(args)
         end
 
-        unless [true, :receives].include?(skip_validations) || receives.empty?
-          validate_received_arguments(args)
-        end
+        return unless validate_received_arguments?(skip_validations)
+        validate_received_arguments(args)
+      end
+
+      # Dont validate if asked to skip or requires is empty
+      def validate_required_arguments?(skip_validations)
+        return if [true, :requires].include?(skip_validations)
+        requires.any?
+      end
+
+      # Dont validate if asked to skip or receives is empty
+      def validate_received_arguments?(skip_validations)
+        return if [true, :receives].include?(skip_validations)
+        receives.any?
       end
 
       # Validates the required arguments

--- a/lib/aye_commander/shareable.rb
+++ b/lib/aye_commander/shareable.rb
@@ -9,7 +9,7 @@ module AyeCommander
       def included(includer)
         super
         includer.extend AyeCommander::Command::ClassMethods
-        %i(@limiters @succeeds @hooks).each do |var|
+        %i[@limiters @succeeds @hooks].each do |var|
           if instance_variable_defined? var
             includer.instance_variable_set var, instance_variable_get(var)
           end
@@ -21,7 +21,7 @@ module AyeCommander
       # the variables to the inheriter.
       def inherited(inheriter)
         super
-        %i(@limiters @succeeds @hooks).each do |var|
+        %i[@limiters @succeeds @hooks].each do |var|
           if instance_variable_defined? var
             inheriter.instance_variable_set var, instance_variable_get(var)
           end

--- a/spec/aye_commander/commander_spec.rb
+++ b/spec/aye_commander/commander_spec.rb
@@ -13,7 +13,7 @@ describe AyeCommander::Commander::ClassMethods do
 
     it 'saves the necessary instance variables for the commander' do
       includer.execute :taco, :burrito
-      expect(includer2.executes).to eq %i(taco burrito)
+      expect(includer2.executes).to eq %i[taco burrito]
     end
   end
 
@@ -25,7 +25,7 @@ describe AyeCommander::Commander::ClassMethods do
 
     it 'saves the necessary instance variables for the commander' do
       commander.execute :taco, :burrito
-      expect(inheriter.executes).to eq %i(taco burrito)
+      expect(inheriter.executes).to eq %i[taco burrito]
     end
   end
 
@@ -62,7 +62,7 @@ describe AyeCommander::Commander::ClassMethods do
   context '.execute' do
     it 'adds the received arguments to the executes array' do
       commander.execute :taco, :burrito
-      expect(commander.executes).to eq %i(taco burrito)
+      expect(commander.executes).to eq %i[taco burrito]
     end
   end
 

--- a/spec/aye_commander/hookable_spec.rb
+++ b/spec/aye_commander/hookable_spec.rb
@@ -1,11 +1,11 @@
 describe AyeCommander::Hookable::ClassMethods do
   include_context :command
 
-  %i(before around after aborted).each do |kind|
+  %i[before around after aborted].each do |kind|
     context ".#{kind}" do
       it "adds the args to the #{kind} hooks array" do
         command.send kind, :some, :method
-        expect(command.send("#{kind}_hooks")).to eq [:some, :method]
+        expect(command.send("#{kind}_hooks")).to eq %i[some method]
         expect(command.instance_variable_get(:@hooks)).to_not be_empty
         expect(command.instance_variable_get(:@hooks).default).to be_empty
       end
@@ -19,13 +19,13 @@ describe AyeCommander::Hookable::ClassMethods do
       it 'adds the args at the end of the array' do
         command.send kind, :first
         command.send kind, :second, :third
-        expect(command.send("#{kind}_hooks")).to eq [:first, :second, :third]
+        expect(command.send("#{kind}_hooks")).to eq %i[first second third]
       end
 
       it 'adds the args at the beginning of the array with the prepend option' do
         command.send kind, :first
         command.send kind, :second, :third, prepend: true
-        expect(command.send("#{kind}_hooks")).to eq [:second, :third, :first]
+        expect(command.send("#{kind}_hooks")).to eq %i[second third first]
       end
     end
 
@@ -41,7 +41,7 @@ describe AyeCommander::Hookable::ClassMethods do
     end
   end
 
-  %i(before after aborted).each do |kind|
+  %i[before after aborted].each do |kind|
     context ".call_#{kind}_hooks" do
       before :each do
         body = -> { success? }

--- a/spec/aye_commander/inspectable_spec.rb
+++ b/spec/aye_commander/inspectable_spec.rb
@@ -20,7 +20,7 @@ describe AyeCommander::Inspectable do
 
     it 'gives a hash representation of the innards of the class with the requested values' do
       result = { :@variable => :something, :@other => :potato }
-      expect(instance.to_hash([:@variable, :other])).to eq result
+      expect(instance.to_hash(%i[@variable other])).to eq result
     end
   end
 

--- a/spec/aye_commander/limitable_spec.rb
+++ b/spec/aye_commander/limitable_spec.rb
@@ -1,6 +1,6 @@
 describe AyeCommander::Limitable::ClassMethods do
   include_context :command
-  let(:args)      { %i(arg1 arg2) }
+  let(:args) { %i[arg1 arg2] }
 
   context '.uses' do
     it 'should call save_variable' do
@@ -17,7 +17,7 @@ describe AyeCommander::Limitable::ClassMethods do
     end
   end
 
-  %i(receives requires returns).each do |limiter|
+  %i[receives requires returns].each do |limiter|
     context ".#{limiter}" do
       before :each do
         command.public_send limiter, *args
@@ -34,12 +34,12 @@ describe AyeCommander::Limitable::ClassMethods do
 
       it 'should add consecutive values without any problem' do
         command.public_send limiter, :arg3
-        expect(command.limiters[limiter]).to eq %i(arg1 arg2 arg3)
+        expect(command.limiters[limiter]).to eq %i[arg1 arg2 arg3]
       end
 
       it 'should not add repeated args' do
         command.public_send limiter, :arg1, :arg4
-        expect(command.limiters[limiter]).to eq %i(arg1 arg2 arg4)
+        expect(command.limiters[limiter]).to eq %i[arg1 arg2 arg4]
       end
     end
   end

--- a/spec/aye_commander/status_spec.rb
+++ b/spec/aye_commander/status_spec.rb
@@ -7,30 +7,30 @@ describe AyeCommander::Status::ClassMethods do
     end
 
     it 'returns whathever the :@succeds class instance variable contains' do
-      command.instance_variable_set :@succeeds, %i(im a little teapot)
-      expect(command.succeeds).to eq %i(im a little teapot)
+      command.instance_variable_set :@succeeds, %i[im a little teapot]
+      expect(command.succeeds).to eq %i[im a little teapot]
     end
   end
 
   context '.suceeds_with' do
-    let(:args) { %i(succ1 succ2) }
+    let(:args) { %i[succ1 succ2] }
 
     before :each do
       command.succeeds_with(*args)
     end
 
     it 'adds the values to the succeeds array' do
-      expect(command.succeeds).to eq %i(success succ1 succ2)
+      expect(command.succeeds).to eq %i[success succ1 succ2]
     end
 
     it 'allows consecutive succeeds' do
       command.succeeds_with :potato
-      expect(command.succeeds).to eq %i(success succ1 succ2 potato)
+      expect(command.succeeds).to eq %i[success succ1 succ2 potato]
     end
 
     it 'doesnt add repeated succeeds' do
       command.succeeds_with(*args)
-      expect(command.succeeds).to eq %i(success succ1 succ2)
+      expect(command.succeeds).to eq %i[success succ1 succ2]
     end
 
     it 'removes :success from the array if called with the exclude_suceed option' do


### PR DESCRIPTION
The styling guide has made some changes, which made the current syntax deprecated.
- Updated the syntax where applicable
- Added rubocop config so the specs can also be copped