### PR TITLE
Bug: Fix an issue when inheriting the command

### DIFF
--- a/lib/aye_commander/shareable.rb
+++ b/lib/aye_commander/shareable.rb
@@ -11,7 +11,7 @@ module AyeCommander
         includer.extend AyeCommander::Command::ClassMethods
         %i[@limiters @succeeds @hooks].each do |var|
           if instance_variable_defined? var
-            includer.instance_variable_set var, instance_variable_get(var)
+            includer.instance_variable_set var, instance_variable_get(var).dup
           end
         end
       end
@@ -23,7 +23,7 @@ module AyeCommander
         super
         %i[@limiters @succeeds @hooks].each do |var|
           if instance_variable_defined? var
-            inheriter.instance_variable_set var, instance_variable_get(var)
+            inheriter.instance_variable_set var, instance_variable_get(var).dup
           end
         end
       end

--- a/spec/aye_commander/shareable_spec.rb
+++ b/spec/aye_commander/shareable_spec.rb
@@ -19,6 +19,12 @@ describe AyeCommander::Shareable::ClassMethods do
       expect(includer2.succeeds).to include :inclusion
       expect(includer2.send(:hooks)).to be_empty
     end
+
+    it 'does not add the instance variables of the includers to the original' do
+      includer.requires :something
+      includer2.requires :other
+      expect(includer.requires).to_not include :other
+    end
   end
 
   context '.inherited' do
@@ -33,6 +39,12 @@ describe AyeCommander::Shareable::ClassMethods do
       expect(inheriter.receives).to include :hopefully_this
       expect(inheriter.succeeds).to include :inclusion
       expect(inheriter.send(:hooks)).to be_empty
+    end
+
+    it 'does not add the instance variables of the inheriter to the original' do
+      command.requires :something
+      inheriter.requires :other
+      expect(command.requires).to_not include :other
     end
   end
 end


### PR DESCRIPTION
Just found a fresh one. I would be surprised this was not found before
if someone actually used the gem. *sadface

Basically when using inheritance the limiters/succeeds/hooks were
pointing to the same object id so when you updated one it propagated to
the others. I'm a bit interested on why I was not able to reproduce this
behaviour with mixins but a fix was applied just in case nontheless.